### PR TITLE
開発用データベース変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:3.1.4
-RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs npm
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs npm iputils-ping
 RUN npm install -g yarn esbuild sass vite
 RUN mkdir /lets_travel
 WORKDIR /lets_travel

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,27 +1,22 @@
-# SQLite. Versions 3.8.0 and up are supported.
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem "sqlite3"
-#
 default: &default
-  adapter: sqlite3
+  adapter: postgresql
+  encoding: unicode
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  timeout: 5000
+  username: postgres
+  password: lets_travel
+  host: db # Dockerのサービス名
+  port: 5432
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: lets_travel_development
 
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  database: lets_travel_test
 
 production:
   <<: *default
-  adapter: postgresql
-  encoding: unicode
-  pool: 5
+  database: lets_travel_production
+  username: <%= ENV['DATABASE_USERNAME'] %>
+  password: <%= ENV['DATABASE_PASSWORD'] %>

--- a/db/migrate/20241003161813_rename_end_budget_and_add_budget_to_boards.rb
+++ b/db/migrate/20241003161813_rename_end_budget_and_add_budget_to_boards.rb
@@ -1,7 +1,53 @@
 class RenameEndBudgetAndAddBudgetToBoards < ActiveRecord::Migration[7.0]
-  def change
+  def up
+    # カラムのリネーム
     rename_column :boards, :end_budget, :end_duration
-    change_column :boards, :end_duration, :datetime
+    
+    if ActiveRecord::Base.connection.adapter_name == 'PostgreSQL'
+      # 新しい一時カラムを追加して、データを移行する
+      add_column :boards, :end_duration_temp, :timestamp
+      
+      # 既存のintegerデータを新しいtimestampカラムに変換
+      Board.reset_column_information
+      Board.find_each do |board|
+        if board.end_duration.present?
+          # ここで適切に変換（たとえば、UNIXタイムスタンプとして扱う）
+          board.update_column(:end_duration_temp, Time.at(board.end_duration).to_datetime)
+        end
+      end
+
+      # 古いカラムを削除し、新しいカラムをリネーム
+      remove_column :boards, :end_duration
+      rename_column :boards, :end_duration_temp, :end_duration
+    else
+      # 他のデータベースではそのままdatetime型に変更
+      change_column :boards, :end_duration, :datetime
+    end
+    
+    # budgetカラムを追加
     add_column :boards, :budget, :integer
+  end
+
+  def down
+    # 元に戻す場合の処理
+    rename_column :boards, :end_duration, :end_budget
+
+    if ActiveRecord::Base.connection.adapter_name == 'PostgreSQL'
+      add_column :boards, :end_budget_temp, :integer
+
+      Board.reset_column_information
+      Board.find_each do |board|
+        if board.end_budget.present?
+          board.update_column(:end_budget_temp, board.end_budget.to_i)
+        end
+      end
+
+      remove_column :boards, :end_budget
+      rename_column :boards, :end_budget_temp, :end_budget
+    else
+      change_column :boards, :end_budget, :integer
+    end
+
+    remove_column :boards, :budget
   end
 end

--- a/db/migrate/20241021164937_change_end_duration_type_in_boards.rb
+++ b/db/migrate/20241021164937_change_end_duration_type_in_boards.rb
@@ -1,25 +1,33 @@
 class ChangeEndDurationTypeInBoards < ActiveRecord::Migration[7.0]
   def up
-    add_column :boards, :end_duration_temp, :timestamp_
-    Board.reset_column_information
-    Board.find_each do |board|
-      if board.end_duration.present?
-        board.update_column(:end_duration_temp, board.end_duration.to_datetime)
+    if ActiveRecord::Base.connection.adapter_name == 'PostgreSQL'
+      add_column :boards, :end_duration_temp, :timestamp
+      
+      Board.reset_column_information
+      Board.find_each do |board|
+        if board.end_duration.present?
+          board.update_column(:end_duration_temp, board.end_duration.to_datetime)
+        end
       end
+
+      remove_column :boards, :end_duration
+      rename_column :boards, :end_duration_temp, :end_duration
     end
-    remove_column :boards, :end_duration
-    rename_column :boards, :end_duration_temp, :end_duration
   end
 
   def down
-    add_column :boards, :end_duration_temp, :date
-    Board.reset_column_information
-    Board.find_each do |board|
-      if board.end_duration.present?
-        board.update_column(:end_duration_temp, board.end_duration.to_date)
+    if ActiveRecord::Base.connection.adapter_name == 'PostgreSQL'
+      add_column :boards, :end_duration_temp, :integer
+      
+      Board.reset_column_information
+      Board.find_each do |board|
+        if board.end_duration.present?
+          board.update_column(:end_duration_temp, board.end_duration.to_i)
+        end
       end
+
+      remove_column :boards, :end_duration
+      rename_column :boards, :end_duration_temp, :end_duration
     end
-    remove_column :boards, :end_duration
-    rename_column :boards, :end_duration_temp, :end_duration
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,6 +11,9 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[7.0].define(version: 2024_10_21_181635) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -47,12 +50,12 @@ ActiveRecord::Schema[7.0].define(version: 2024_10_21_181635) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "budget"
-    t.datetime "end_duration"
+    t.datetime "end_duration", precision: nil
   end
 
   create_table "comments", force: :cascade do |t|
-    t.integer "user_id"
-    t.integer "board_id"
+    t.bigint "user_id"
+    t.bigint "board_id"
     t.text "body", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -61,7 +64,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_10_21_181635) do
   end
 
   create_table "savings", force: :cascade do |t|
-    t.integer "user_id", null: false
+    t.bigint "user_id", null: false
     t.date "date_and_time"
     t.integer "value", null: false
     t.datetime "created_at", null: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,13 @@ services:
     image: postgres
     environment:
       - POSTGRES_PASSWORD=lets_travel
+      - POSTGRES_USER=postgres
+      - POSTGRES_DB=lets_travel_development
       - POSTGRES_HOST_AUTH_METHOD=trust
+    ports:
+      - "5432:5432" 
+    volumes:
+      - pgdata:/var/lib/postgresql/data
   web:
     build: .
     command: sh -c "rm -f tmp/pids/server.pid; bundle exec rails s -p 3000 -b '0.0.0.0'"
@@ -26,3 +32,5 @@ services:
       - NODE_ENV=development
       - RAILS_ENV=development
     command: sh -c "yarn install && yarn build"
+volumes:
+  pgdata: 


### PR DESCRIPTION
ローカル開発でSQlite3を使用し、herokuでのデプロイでPostgresqlを使用することとしていたが、デプロイのdb:migrate時にデータ型変換がうまくいかなかったので、開発環境dbもPostgresqlへ変更した。