### PR TITLE
auto_login実装

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,7 +11,8 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      session[:user_id] = @user.id
+      auto_login(@user)
+      # session[:user_id] = @user.idではセッションの有効期限やRemember Meを自分で実装しなければいけない
       redirect_to root_path, success: 'ユーザー登録が完了しました'
     else
       flash.now[:danger] = 'ユーザー登録に失敗しました'


### PR DESCRIPTION
sorceryのauto-loginメソッドを実装。
すでにsession[:user_id] = @user.idとすることでログイン時の自動ログイン機能だけは機能していたが、セッションidを直接入力する方法ではセッション有効期限やRemember Meを手動で設定しなければならないことが判明し、また、セッションの一貫性やセキュリティの関係から同メソッドを実装することとした。